### PR TITLE
pom.xml updates to allow building even with javadoc issues

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -77,6 +77,7 @@
                 <configuration>
                     <show>private</show>
                     <docfilessubdirs>true</docfilessubdirs>
+                    <failOnError>false</failOnError>
                     <linksource>true</linksource>
                 </configuration>
                 <executions>


### PR DESCRIPTION
Added a configuration flag to the javadoc pom to not fail on error while javadocs are being updated.